### PR TITLE
Fix/79: MSW 핸들러 불일치로 인한 API 요청 오류 수정

### DIFF
--- a/src/mock/handlers.ts
+++ b/src/mock/handlers.ts
@@ -1,9 +1,9 @@
 import { http, HttpResponse } from 'msw';
-import { API_BASE_URL } from '../api/apiClient';
+// import { API_BASE_URL } from '../api/apiClient';
 
 export const handlers = [
   // Home(질문) 페이지 questions 가져오기
-  http.get(`${API_BASE_URL}/api/questions/random`, ({ request }) => {
+  http.get('*/api/questions/random', ({ request }) => {
     const url = new URL(request.url);
     const userId = url.searchParams.get('user_id');
     if (userId === '1') {
@@ -17,7 +17,7 @@ export const handlers = [
     }
   }),
   // Home(질문) 페이지 users 가져오기
-  http.get(`${API_BASE_URL}/api/user`, ({ request }) => {
+  http.get('*/api/user', ({ request }) => {
     const url = new URL(request.url);
     const userId = url.searchParams.get('userId');
     if (userId === '1') {
@@ -56,7 +56,7 @@ export const handlers = [
     }
   }),
   // Archive 질문(피드백) 가져오기
-  http.get(`${API_BASE_URL}/api/answers`, ({ request }) => {
+  http.get('*/api/answers', ({ request }) => {
     const url = new URL(request.url);
     const userId = url.searchParams.get('userId');
     if (userId === '1') {


### PR DESCRIPTION
### 🎨 작업 내용 (Description)

- Vercel 배포 환경에서 발생하는 MSW 핸들러 불일치 문제 해결

- 기존에는 VITE_API_BASE_URL을 사용하여 핸들러의 전체 URL을 생성했으나, 
이로 인해 실제 요청이 발생하는 도메인과 핸들러가 리스닝하는 도메인이 달라 요청을 가로채지 못하는 문제 발생

- 핸들러 경로에 와일드카드(*)를 적용하여 호스트 이름과 관계없이 일치하는 API 경로의 모든 요청을 처리하도록 수정 
  이를 통해 로컬 개발 환경과 배포 환경 모두에서 MSW가 일관되게 동작하도록 보장

### #️⃣ 관련 이슈 (Related Issues)

Close #79 

### 📢 리뷰어에게 전달할 말 (Words for Reviewer)

-

---

<details>
<summary><strong>👨‍👩‍👧‍👦 우리 팀 리뷰 규칙 (Review Rules)</strong></summary>

코드 리뷰는 `Pn`룰에 따라 작성해주세요. Reviewer가 남기는 피드백의 중요도를 표현하기 위한 규칙입니다.

- **P1: 🙏 꼭 반영해주세요 (Request Changes)**
  - 수정하지 않으면 이슈가 발생할 수 있거나, 중대한 약속(컨벤션)을 위반하는 경우
- **P2: 💡 적극적으로 고려해주세요 (Comment)**
  - 더 좋은 방법이 있거나, 코드 개선에 도움이 되는 제안
- **P3: 💬 참고만 해주세요 (Chore)**
  - 이런 방법도 있다는 것을 알리는 사소한 의견이나 잡담
  </details>
