### PR TITLE
Feat/119 : 피드백 페이지 레벨 선택 모달 추가 

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,10 +7,10 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.11.6'
-const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
-const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
-const activeClientIds = new Set()
+const PACKAGE_VERSION = '2.11.3';
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82';
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
+const activeClientIds = new Set();
 
 addEventListener('install', function () {
   self.skipWaiting();

--- a/src/pages/Feedback/components/LevelModal.tsx
+++ b/src/pages/Feedback/components/LevelModal.tsx
@@ -117,7 +117,6 @@ const ButtonWrapper = styled.div`
   width: 100%;
 `;
 
-// SharedButton을 확장(extend)하여 스타일만 변경
 const CloseButton = styled(SharedButton)`
   flex: 1;
   background-color: ${({ theme }) => theme.colors.greyLighter};

--- a/src/pages/Feedback/components/LevelModal.tsx
+++ b/src/pages/Feedback/components/LevelModal.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+
+import styled from '@emotion/styled';
+import { Star } from 'lucide-react';
+
+import SharedButton from '../../../shared/ui/SharedButton';
+
+interface LevelModalProps {
+  currentLevel: number;
+  onClose: () => void;
+  onSave: (newLevel: number) => Promise<void>;
+}
+
+const LevelModal = ({ currentLevel, onClose, onSave }: LevelModalProps) => {
+  const [selectedLevel, setSelectedLevel] = useState(currentLevel);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // 별을 클릭했을 때 선택된 난이도 업데이트
+  const handleLevelClick = (level: number) => {
+    setSelectedLevel(level);
+  };
+
+  const handleSaveClick = async () => {
+    setIsSaving(true);
+    try {
+      await onSave(selectedLevel);
+    } catch (error) {
+      console.error('난이도 저장 실패 :', error);
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <ModalOverlay onClick={onClose}>
+      {/* 2. 모달 컨텐츠 (클릭해도 닫히지 않게 이벤트 전파 차단) */}
+      <ModalContainer onClick={(e) => e.stopPropagation()}>
+        <ModalTitle>난이도 설정</ModalTitle>
+        <ModalText>이 질문의 난이도를 설정해주세요.</ModalText>
+
+        <StarWrapper>
+          {[1, 2, 3, 4, 5].map((starIndex) => (
+            <StyledStar
+              key={starIndex}
+              onClick={() => handleLevelClick(starIndex)}
+              fill={starIndex <= selectedLevel ? '#FFD700' : 'none'}
+              color="#FFD700"
+              size={40}
+            />
+          ))}
+        </StarWrapper>
+
+        <ButtonWrapper>
+          <CloseButton type="button" onClick={onClose} disabled={isSaving}>
+            취소
+          </CloseButton>
+          <SaveButton type="button" onClick={handleSaveClick} disabled={isSaving}>
+            {isSaving ? '저장 중...' : '저장 및 이동'}
+          </SaveButton>
+        </ButtonWrapper>
+      </ModalContainer>
+    </ModalOverlay>
+  );
+};
+
+export default LevelModal;
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`;
+
+const ModalContainer = styled.div`
+  background-color: #ffffff;
+  padding: 32px;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+`;
+
+const ModalTitle = styled.h2`
+  font-size: ${({ theme }) => theme.typography.fontSizes.h2};
+  font-weight: ${({ theme }) => theme.typography.fontWeights.bold};
+  color: ${({ theme }) => theme.colors.black};
+  margin: 0;
+`;
+
+const ModalText = styled.p`
+  font-size: ${({ theme }) => theme.typography.fontSizes.body};
+  color: ${({ theme }) => theme.colors.textSecondary};
+  margin: 0;
+`;
+
+const StarWrapper = styled.div`
+  display: flex;
+  gap: 16px;
+`;
+
+const StyledStar = styled(Star)`
+  cursor: pointer;
+  transition: all 0.1s ease-in-out;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 12px;
+  width: 100%;
+`;
+
+// SharedButton을 확장(extend)하여 스타일만 변경
+const CloseButton = styled(SharedButton)`
+  flex: 1;
+  background-color: ${({ theme }) => theme.colors.greyLighter};
+  color: ${({ theme }) => theme.colors.text};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.grey};
+  }
+`;
+
+const SaveButton = styled(SharedButton)`
+  flex: 1;
+`;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -48,7 +48,8 @@ const HomePage = () => {
       setAnswerState('answered');
       navigate(generatePath(ROUTE_PATH.FEEDBACK, { id: String(data.feedbackId) }));
     },
-    onError: (_error: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onError: (_error: unknown) => {
       alert('답변 제출에 실패했습니다. 다시 시도해주세요.');
     },
   });


### PR DESCRIPTION
### 🎨 작업 내용 (Description)

- 답변 제출후 넘어가는 피드백페이지에서 아카이브 이동 버튼 누르면 레벨 선택할 수 있는 모달 추가 

### #️⃣ 관련 이슈 (Related Issues)

Close #119

### 📢 리뷰어에게 전달할 말 (Words for Reviewer)

- ***

<details>
<summary><strong>👨‍👩‍👧‍👦 우리 팀 리뷰 규칙 (Review Rules)</strong></summary>

코드 리뷰는 `Pn`룰에 따라 작성해주세요. Reviewer가 남기는 피드백의 중요도를 표현하기 위한 규칙입니다.

- **P1: 🙏 꼭 반영해주세요 (Request Changes)**
  - 수정하지 않으면 이슈가 발생할 수 있거나, 중대한 약속(컨벤션)을 위반하는 경우
- **P2: 💡 적극적으로 고려해주세요 (Comment)**
  - 더 좋은 방법이 있거나, 코드 개선에 도움이 되는 제안
- **P3: 💬 참고만 해주세요 (Chore)**
  - 이런 방법도 있다는 것을 알리는 사소한 의견이나 잡담
  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced inline level control with a Level selection modal; archive navigation now routes through this modal and saves level before navigating.
  * Added modal save flow with loading and improved error handling.

* **Bug Fixes**
  * Starring toggle and memo state updates now follow a consistent payload and UI update flow.

* **Style**
  * Heart (star) fill now uses theme-based colors; minor text/message updates for clearer errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->